### PR TITLE
patch version for documentation correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning].
 
 ## Fixed
 
-- version number of `composer.json` corrected to reflect release version
+- version number of `composer.json` corrected to reflect release version ([#5])
 
 
 ## 1.0.0 - 2024-07-29
@@ -33,3 +33,4 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]:http://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]:http://semver.org/spec/v2.0.0.html
 [#2]:https://github.com/AxeTools/CachingTrait/pull/2
+[#5]:https://github.com/AxeTools/CachingTrait/pull/5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning].
 
 - The 2.x branch will be added to support php ^8.0
 
+## 1.0.1 - 2024-07-29
+
+## Fixed
+
+- version number of `composer.json` corrected to reflect release version
+
+
 ## 1.0.0 - 2024-07-29
 
 ### Added


### PR DESCRIPTION
# Description

There was a miss matched version entry in the `composer.json` file that conflicted with the release version of release 1.0.0.  This needed to be corrected for packagist to correctly parse the version.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Doc change no testing

# Checklist:

- [x] I have made corresponding changes to the documentation
